### PR TITLE
Switch to node try-finally to decide when to stop rwebppl; closes #37

### DIFF
--- a/inst/js/rwebppl
+++ b/inst/js/rwebppl
@@ -62,4 +62,10 @@ function main() {
 
 }
 
-main();
+try {
+  main();
+} finally {
+  var argv = parseArgs(process.argv.slice(2));
+  var finishFile = argv._[2];
+  fs.writeFile(finishFile,  "");
+}


### PR DESCRIPTION
Previously, we wrote stdout to the console and stderr to a file.
(WebPPL would write its output to a file as well, so the only thing
going to stdout was console.log statements.) This was so we could handle
3 sources of output separately: print statements, error messsages, and
webppl output. We would then wait for either the stderr file to exist or the
webppl output file to exist, and then proceed (with either tidying the data
or exiting). We ran into issue #37 with `console.warn()` statements which
would be passed to stderr, and be treated as errors even though they are just
warnings.

In this commit, we use `try { .. } finally { .. }` inside the `rwebppl` binary (js file)
so that the call will try to run the webppl program (via `main()`) and whatever
happens, run `finally { ... }`, which writes out a file that says that webppl is done.
RWebPPL is checking for that end file to exist.

We now longer write stderr to a file but just pass it to the console.
This displays the appropriate behavior for both `console.warn()` and `console.err()` statements.
