### PR TITLE
use parseable args & unique tmp files

### DIFF
--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -272,7 +272,6 @@ run_webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
 
   # find location of rwebppl JS script, within rwebppl R package
   script_path <- file.path(rwebppl_path(), "js/rwebppl")
-  add_packages <- packages
 
   # if data supplied, create a webppl package that exports the data as data_var
   if (!is.null(data)) {
@@ -286,7 +285,7 @@ run_webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
       data_string <- jsonlite::toJSON(data)
       cat(sprintf("module.exports = JSON.parse('%s')", data_string),
           file = file.path(tmp_dir, data_var, "index.js"))
-      add_packages <- c(add_packages, file.path(tmp_dir, data_var))
+      packages <- c(packages, file.path(tmp_dir, data_var))
     }
   }
 
@@ -317,42 +316,27 @@ run_webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
     modified_program_code <- paste(modified_program_code, infer, sep = "\n")
   }
 
-  # write modified_program_code to temporary file and store its name in file_arg
-  cat(modified_program_code, file = (file_arg <- tempfile()))
-
-  # set output_arg to path to temporary file with a unique key
-  uid <- uuid::UUIDgenerate()
-  output_arg <- sprintf("/tmp/webppl_output_%s", uid)
-
-  # create --require argument out of each package name
-  if (!is.null(add_packages)) {
-    package_args <- unlist(lapply(add_packages,
-                                  function(x) paste("--require", x)))
-  } else {
-    package_args <- ""
-  }
-
-  # clear paths where rwebppl JS script will write output, errors, or finish file
-  output_file <- output_arg
-  if (file.exists(output_file)) {
-    file.remove(output_file)
-  }
-  error_file <- "/tmp/webppl_error"
-  if (file.exists(error_file)) {
-    file.remove(error_file)
-  }
+  # create tmp files for program code, program output, and finish signal
+  uid <- uuid::UUIDgenerate()  
+  program_file <- sprintf("/tmp/webppl_program_%s", uid)
+  output_file <- sprintf("/tmp/webppl_output_%s", uid)
   finish_file <- sprintf("/tmp/webppl_finished_%s", uid)
-  finish_arg <- finish_file
-  if (file.exists(finish_file)) {
-    file.remove(finish_file)
-  }
+
+  # create args to pass to rwebppl js, including packages
+  program_arg <- sprintf("--programFile %s", program_file)
+  output_arg <- sprintf("--outputFile %s", output_file)
+  finish_arg <- sprintf("--finishFile %s", finish_file)
+  package_args <- ifelse(!is.null(packages), paste('--require', packages), "")
+
+  # write modified_program_code to temporary program_file
+  cat(modified_program_code, file = program_file)
 
   # run rwebppl JS script with model file and packages as arguments
   # any output to stdout gets sent to the R console while command runs
-  system2(script_path, args = c(file_arg, output_arg, finish_arg, package_args),
+  system2(script_path, args = c(program_arg, output_arg, finish_arg, package_args),
           stdout = "", stderr = "", wait = FALSE)
 
-  # wait for output file or error file to exist
+  # wait for finish file to exist
   while (!(file.exists(finish_file))) {
     Sys.sleep(0.25)
   }

--- a/inst/js/rwebppl
+++ b/inst/js/rwebppl
@@ -4,9 +4,10 @@ var webppl = require('./webppl')
 var webppl_main = require('./webppl/src/main');
 var util = require('./webppl/src/util');
 var pkg = require('./webppl/src/pkg');
-var parseArgs = require('./webppl/node_modules/minimist');
+var argv = require('./webppl/node_modules/minimist')(process.argv.slice(2));
 var path = require('path');
 var fs = require('fs');
+
 
 function writeWebPPLValue(x, file) {
   if (dists.isDist(x) && x.isContinuous) {
@@ -24,15 +25,10 @@ function writeWebPPLValue(x, file) {
 
 
 function main() {
-
-  var argv = parseArgs(process.argv.slice(2));
-  var programFile = argv._[0];
-  var outputFile = argv._[1];
-
-  var code = fs.readFileSync(programFile, 'utf8');
+  var code = fs.readFileSync(argv.programFile, 'utf8');
 
   var packagePaths = [
-    path.join(path.dirname(programFile), 'node_modules'),
+    path.join(path.dirname(argv.programFile), 'node_modules'),
     pkg.globalPkgDir()
   ];
 
@@ -46,7 +42,7 @@ function main() {
   });
 
   webppl.run(code, function(s,x) {
-    writeWebPPLValue(x, outputFile);
+    writeWebPPLValue(x, argv.outputFile);
   }, {
     bundles: webppl_main.parsePackageCode(packages, false)
   });
@@ -56,7 +52,5 @@ function main() {
 try {
   main();
 } finally {
-  var argv = parseArgs(process.argv.slice(2));
-  var finishFile = argv._[2];
-  fs.writeFileSync(finishFile,  "");
+  fs.writeFileSync(argv.finishFile,  "");
 }


### PR DESCRIPTION
Closes #43 and #44.

The only change I wasn't sure about was removing the `add_packages <- packages` assignment: this seemed redundant to me, since R is a pass-by-value language and `packages` is never used again.