### PR TITLE
Now Windows-compatible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@
 .RData
 .Ruserdata
 .DS_Store
-inst/js/webppl
-inst/js/package.json
-inst/js/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .RData
 .Ruserdata
 .DS_Store
+inst/js/webppl
+inst/js/package.json
+inst/js/package-lock.json

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     doParallel,
     foreach,
     tidyr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.2.3
 SystemRequirements: node
 Suggests: testthat
 WebPPLVersion: 0.9.7

--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -57,7 +57,7 @@ install_webppl <- function(webppl_version) {
   }
   message("installing webppl ...", appendLF = FALSE)
   if (system_os() == "Windows") {
-    npm_info <- system("npm info webppl versions --json")
+    npm_info <- system("npm info webppl versions --json", intern = TRUE)
   }
   else { 
     npm_info <- system2("npm", args = c("info", "webppl", "versions", "--json"),
@@ -89,9 +89,9 @@ install_webppl <- function(webppl_version) {
   } else {
     # This doesn't work for Windows yet
     if (system_os() == "Windows") {
-      system(paste("powershell -ExecutionPolicy ByPass -File", 
-                   paste("\"", file.path(rwebppl_path(), "powershell", "install-dev-webppl.ps1"), "\"", sep=""), 
-                   paste("\"", rwebppl_path(), "\"", sep=""), webppl_version))
+      # system(paste("powershell -ExecutionPolicy ByPass -File", 
+      #              paste("\"", file.path(rwebppl_path(), "powershell", "install-dev-webppl.ps1"), "\"", sep=""), 
+      #              paste("\"", rwebppl_path(), "\"", sep=""), webppl_version))
     }
     else {
       system2(file.path(rwebppl_path(), "bash", "install-dev-webppl.sh"),

--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -56,8 +56,13 @@ install_webppl <- function(webppl_version) {
     clean_webppl()
   }
   message("installing webppl ...", appendLF = FALSE)
-  npm_info <- system2("npm", args = c("info", "webppl", "versions", "--json"),
-                      stdout = TRUE)
+  if (system_os() == "Windows") {
+    npm_info <- system("npm info webppl versions --json")
+  }
+  else { 
+    npm_info <- system2("npm", args = c("info", "webppl", "versions", "--json"),
+                        stdout = TRUE)
+  }
   npm_versions <- jsonlite::fromJSON(paste(npm_info, collapse = ""))
   if (webppl_version %in% npm_versions) {
     rwebppl_json <- file.path(rwebppl_path(), "json", "rwebppl.json")

--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -1,3 +1,6 @@
+# Determine the shell/scripts to use based on user OS
+system_os <- function() Sys.info()["sysname"]
+
 # Path to rwebppl R package
 rwebppl_path <- function() system.file(package = "rwebppl")
 
@@ -10,15 +13,30 @@ global_pkg_path <- function() path.expand("~/.webppl")
 
 # Internal function that checks whether a file exists
 file_exists <- function(path) {
-  args <- c("!", "-e", path, ";", "echo", "$?")
-  existsFlag <- suppressWarnings(system2("test", args = args, stdout = T))
-  return(existsFlag == 1)
+  if (system_os() == "Windows") {
+    args <- c(path)
+    existsFlag <- suppressWarnings(
+      system(paste("powershell -ExecutionPolicy ByPass -Command Test-Path",
+                   paste("\"'", args, "'\"", sep="")), intern = T))
+    existsFlag <- ifelse(existsFlag == "True", 1, 0)
+    return(existsFlag == 1)
+  }
+  else {
+    args <- c("!", "-e", path, ";", "echo", "$?")
+    existsFlag <- suppressWarnings(system2("test", args = args, stdout = T))
+    return(existsFlag == 1)  
+  }
 }
 
 # Internal function that cleans the local webppl install
 clean_webppl <- function() {
   message("cleaning old version... ", appendLF = FALSE)
-  system2("rm", args = c('-r', webppl_install()))
+  if (system_os() == "Windows") {
+    system(paste("powershell -ExecutionPolicy ByPass -Command rm -r", webppl_install()))
+  }
+  else {
+    system2("rm", args = c('-r', webppl_install()))  
+  }
 }
 
 #' Installs webppl locally
@@ -33,7 +51,7 @@ clean_webppl <- function() {
 #' \dontrun{install_webppl('0.9.6')}
 #' \dontrun{install_webppl('4bd2452333d24c122aee98c3206584bc39c6096a')}
 install_webppl <- function(webppl_version) {
-  # first, clean up any webppl version that might already exist
+  # First, clean up any webppl version that might already exist
   if(file_exists(webppl_executable())) {
     clean_webppl()
   }
@@ -46,19 +64,35 @@ install_webppl <- function(webppl_version) {
     rwebppl_meta <- jsonlite::fromJSON(readLines(rwebppl_json))
     rwebppl_meta$dependencies$webppl <- webppl_version
     webppl_json <- file.path(rwebppl_path(), "js", "package.json")
-
-    # Executable bit should be tracked by git but chmod just in case
-    system2('chmod', args = c('+x', file.path(rwebppl_path(), "bash", "*")))
-
     writeLines(jsonlite::toJSON(rwebppl_meta, auto_unbox = TRUE, pretty = TRUE),
                webppl_json)
-    system2(file.path(rwebppl_path(), "bash", "install-webppl.sh"),
-            args = rwebppl_path())
-    system2(file.path(rwebppl_path(), "bash", "rearrange-webppl.sh"),
-            args = rwebppl_path())
+    if (system_os() == "Windows") {
+      system(paste("powershell -ExecutionPolicy ByPass -File", 
+                   paste("\"", file.path(rwebppl_path(), "powershell", "install-webppl.ps1"), "\"", sep=""), 
+                   paste("\"", rwebppl_path(), "\"", sep="")))
+      system(paste("powershell -ExecutionPolicy ByPass -File", 
+                   paste("\"", file.path(rwebppl_path(), "powershell", "rearrange-webppl.ps1"), "\"", sep=""), 
+                   paste("\"", rwebppl_path(), "\"", sep="")))
+    }
+    else {
+      system2(file.path(rwebppl_path(), "bash", "install-webppl.sh"),
+              args = rwebppl_path())
+      system2(file.path(rwebppl_path(), "bash", "rearrange-webppl.sh"),
+              args = rwebppl_path())
+    }
+    
   } else {
-    system2(file.path(rwebppl_path(), "bash", "install-dev-webppl.sh"),
-            args = c(rwebppl_path(), webppl_version))
+    # This doesn't work for Windows yet
+    if (system_os() == "Windows") {
+      system(paste("powershell -ExecutionPolicy ByPass -File", 
+                   paste("\"", file.path(rwebppl_path(), "powershell", "install-dev-webppl.ps1"), "\"", sep=""), 
+                   paste("\"", rwebppl_path(), "\"", sep=""), webppl_version))
+    }
+    else {
+      system2(file.path(rwebppl_path(), "bash", "install-dev-webppl.sh"),
+              args = c(rwebppl_path(), webppl_version))
+    }
+    
   }
   message(" done")
 }
@@ -81,9 +115,15 @@ check_webppl <- function() {
 #' \dontrun{get_webppl_version()}
 get_webppl_version <- function() {
   if (file_exists(webppl_executable())) {
-    version_str <- system2(webppl_executable(), args = c("--version"), stdout = T)
+    if (system_os() == "Windows") {
+      version_str <- substr(system(paste("node", paste("\"", webppl_executable(), "\"", sep=""), "--version"), intern = T), 1, 6) 
+    }
+    else {
+      version_str <- system2(webppl_executable(), args = c("--version"), stdout = T)  
+    }
     message(paste("using webppl version:", version_str))
-  } else {
+  } 
+  else {
     warning("couldn't find local webppl install")
   }
 }
@@ -106,8 +146,16 @@ get_webppl_version <- function() {
 #' @examples
 #' \dontrun{install_webppl_package("babyparse")}
 install_webppl_package <- function(package_name, path = global_pkg_path()) {
-  system2(file.path(rwebppl_path(), "bash", "install_package.sh"),
-          args = c(path, package_name, rwebppl_path()))
+  if (system_os() == "Windows") {
+    system(paste("powershell -ExecutionPolicy ByPass -File", 
+                 paste("\"", file.path(rwebppl_path(), "powershell", "install-package.ps1"), "\"", sep=""), 
+                 paste("\"", path, "\"", sep=""), package_name, 
+                 paste("\"", rwebppl_path(), "\"", sep="")))
+  }
+  else {
+    system2(file.path(rwebppl_path(), "bash", "install_package.sh"),
+            args = c(path, package_name, rwebppl_path()))
+  }
 }
 
 #' Uninstall webppl package
@@ -121,8 +169,16 @@ install_webppl_package <- function(package_name, path = global_pkg_path()) {
 #' @examples
 #' \dontrun{uninstall_webppl_package("babyparse")}
 uninstall_webppl_package <- function(package_name, path = global_pkg_path()) {
-  system2(file.path(rwebppl_path(), "bash", "uninstall_package.sh"),
-          args = c(path, package_name))
+  if (system_os == "Windows") {
+    system(paste("powershell -ExecutionPolicy ByPass -File", 
+                 paste("\"", file.path(rwebppl_path(), "powershell", "uninstall-package.ps1"), "\"", sep=""), 
+                 paste("\"", path, "\"", sep=""), package_name))
+  }
+  else {
+    system2(file.path(rwebppl_path(), "bash", "uninstall_package.sh"),
+            args = c(path, package_name))
+  }
+  
 }
 
 #' Get samples
@@ -179,18 +235,13 @@ countSamples <- function(output, inference_opts) {
   }
 }
 
-tidy_probTable <- function(output, sort_by) {
+tidy_probTable <- function(output) {
   if (class(output$support) == "data.frame") {
     support <- output$support
   } else {
     support <- data.frame(support = output$support)
   }
-  unsorted_probTable <- cbind(support, data.frame(prob = output$probs))
-  if (sort_by == "prob") {
-    return(unsorted_probTable[with(unsorted_probTable, order(-prob)), ])
-  } else {
-    return(unsorted_probTable[with(unsorted_probTable, order(support)), ])
-  }
+  return(cbind(support, data.frame(prob = output$probs)))
 }
 
 tidy_sampleList <- function(output, chains, chain, inference_opts) {
@@ -214,9 +265,9 @@ tidy_sampleList <- function(output, chains, chain, inference_opts) {
   return(ggmcmc_samples)
 }
 
-tidy_output <- function(output, chains = NULL, chain = NULL, inference_opts = NULL, sort_by = NULL) {
+tidy_output <- function(output, chains = NULL, chain = NULL, inference_opts = NULL) {
   if (is_probTable(output)) {
-    return(tidy_probTable(output, sort_by = sort_by))
+    return(tidy_probTable(output))
   } else if (is_sampleList(output)) {
     # Drop redundant score column, if it exists
     if ("score" %in% names(output)) {
@@ -241,91 +292,109 @@ tidy_output <- function(output, chains = NULL, chain = NULL, inference_opts = NU
 #' @param model_var The name by which the model be referenced in the program.
 #' @param inference_opts Options for inference
 #' (see http://webppl.readthedocs.io/en/master/inference.html)
-#' @param random_seed Seed for random number generator
-#' @param sort_by Sort probability table by probability or support (enumeration only)
 #' @param chains Number of chains (this run is one chain).
 #' @param chain Chain number of this run.
 run_webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
-                       data_var = "data", packages = NULL, model_var = "model",
-                       inference_opts = NULL, chains = NULL, random_seed = NULL,
-                       sort_by = "prob", chain = 1) {
+                       data_var = NULL, packages = NULL, model_var = NULL,
+                       inference_opts = NULL, chains = NULL,
+                       chain = 1) {
 
-  # find location of rwebppl JS script, within rwebppl R package
+  # Get OS
+  system_os <- Sys.info()["sysname"]
+  
+  # Find location of rwebppl JS script, within rwebppl R package
   script_path <- file.path(rwebppl_path(), "js/rwebppl")
 
-  # if data supplied, create a webppl package that exports the data as data_var
+  # If data supplied, create a webppl package that exports the data as data_var
   if (!is.null(data)) {
-    tmp_dir <- tempdir()
-    dir.create(file.path(tmp_dir, data_var), showWarnings = FALSE)
-    cat(sprintf('{"name":"%s","main":"index.js"}', data_var),
-        file = file.path(tmp_dir, data_var, "package.json"))
-    data_string <- jsonlite::toJSON(data, digits = NA)
-    cat(sprintf("module.exports = JSON.parse('%s')", data_string),
-        file = file.path(tmp_dir, data_var, "index.js"))
-    packages <- c(packages, file.path(tmp_dir, data_var))
+    if (is.null(data_var)) {
+      warning("ignoring data (supplied without data_var)")
+    } 
+    else {
+      tmp_dir <- tempdir()
+      dir.create(file.path(tmp_dir, data_var), showWarnings = FALSE)
+      cat(sprintf('{"name":"%s","main":"index.js"}', data_var),
+          file = file.path(tmp_dir, data_var, "package.json"))
+      data_string <- jsonlite::toJSON(data, digits = NA)
+      cat(sprintf("module.exports = JSON.parse('%s')", data_string),
+          file = file.path(tmp_dir, data_var, "index.js"))
+      packages <- c(packages, file.path(tmp_dir, data_var))
+    }
   }
 
-  # set modified_program_code to program_code or to contents of program_file
+  # Set modified_program_code to program_code or to contents of program_file
   if (!is.null(program_code)) {
     if (!is.null(program_file)) {
       warning("both program_code and program_file supplied, using program_code")
     }
     modified_program_code <- program_code
-  } else if (!is.null(program_file)) {
+  } 
+  else if (!is.null(program_file)) {
     if (!file.exists(program_file)) {
       stop("program_file does not exist")
     }
     modified_program_code <- paste(readLines(program_file, warn = FALSE),
                                    collapse = "\n")
-  } else {
+  }
+  else {
     stop("supply one of program_code or program_file")
   }
 
-  # if inference_opts supplied, add an Infer call to the program
+  # If inference_opts and model_var supplied, add an Infer call to the program
   if (!is.null(inference_opts)) {
+    if (is.null(model_var)) {
+      stop("when supplying inference_opts, you must also supply model_var")
+    }
     infer <- sprintf("Infer(JSON.parse('%s'), %s)",
                      jsonlite::toJSON(inference_opts, auto_unbox = TRUE),
                      model_var)
     modified_program_code <- paste(modified_program_code, infer, sep = "\n")
   }
 
-  # create tmp files for program code, program output, and finish signal
+  # Create tmp files for program code, program output, and finish signal
   uid <- uuid::UUIDgenerate()
-  program_file <- sprintf("/tmp/webppl_program_%s", uid)
-  output_file <- sprintf("/tmp/webppl_output_%s", uid)
-  finish_file <- sprintf("/tmp/webppl_finished_%s", uid)
-
-  # create args to pass to rwebppl js, including packages
+  if (system_os == "Windows") {
+    program_file <- paste("", tempdir(), sprintf("\\webppl_program_%s", uid), "", sep="")
+    output_file <- paste("", tempdir(), sprintf("\\webppl_output_%s", uid), "", sep="")
+    finish_file <- paste("", tempdir(), sprintf("\\webppl_finished_%s", uid), "", sep="")
+  }
+  else {
+    program_file <- sprintf("/tmp/webppl_program_%s", uid)
+    output_file <- sprintf("/tmp/webppl_output_%s", uid)
+    finish_file <- sprintf("/tmp/webppl_finished_%s", uid)
+  }
+  
+  # Create args to pass to rwebppl js, including packages
   program_arg <- sprintf("--programFile %s", program_file)
   output_arg <- sprintf("--outputFile %s", output_file)
   finish_arg <- sprintf("--finishFile %s", finish_file)
-  if (!is.null(random_seed)) {
-    seed_arg <- sprintf("--random-seed %s", random_seed)
-  } else {
-    seed_arg <- ""
-  }
-
-  if (!is.null(packages)){
+  if (!is.null(packages)) {
     package_args <- unlist(lapply(packages,
                                   function(x){ return( paste('--require', x) ) }))
-  } else {
+  }
+  else {
     package_args <- ""
   }
 
-  # write modified_program_code to temporary program_file
+  # Write modified_program_code to temporary program_file
   cat(modified_program_code, file = program_file)
 
-  # run rwebppl JS script with model file and packages as arguments
-  # any output to stdout gets sent to the R console while command runs
-  system2(script_path, args = c(program_arg, output_arg, finish_arg, package_args, seed_arg),
-          stdout = "", stderr = "", wait = FALSE)
-
-  # wait for finish file to exist
+  # Run rwebppl JS script with model file and packages as arguments
+  # Any output to stdout gets sent to the R console while command runs
+  if (system_os == "Windows") {
+    system(paste("node", paste("\"", script_path, "\"", sep=""), program_arg, output_arg, finish_arg, package_args), wait = F)
+  }
+  else {
+    system2(script_path, args = c(program_arg, output_arg, finish_arg, package_args),
+            stdout = "", stderr = "", wait = FALSE)
+  }
+  
+  # Wait for finish file to exist
   while (!(file.exists(finish_file))) {
     Sys.sleep(0.25)
   }
-
-  # if the command produced non-empty output, collect and tidy the results
+  
+  # If the command produced non-empty output, collect and tidy the results
   if (file.exists(output_file)) {
     output_string <- paste(readLines(output_file, warn = F),
                            collapse = "\n")
@@ -333,16 +402,16 @@ run_webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
       output <- jsonlite::fromJSON(output_string, flatten = TRUE)
       if (!is.null(names(output))) {
         return(tidy_output(output, chains = chains,
-                           chain = chain, inference_opts = inference_opts,
-                           sort_by = sort_by))
-      } else {
+                           chain = chain, inference_opts = inference_opts))
+      }
+      else {
         return(output)
       }
     }
   }
 }
 
-# declare i as a global variable to avoid NOTE from foreach using NSE
+# Declare i as a global variable to avoid NOTE from foreach using NSE
 globalVariables("i")
 
 #' webppl
@@ -364,8 +433,8 @@ globalVariables("i")
 #' webppl(program_code)
 #' }
 webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
-                   data_var = "data", packages = NULL, model_var = "model",
-                   inference_opts = NULL, random_seed = NULL, sort_by = "prob", chains = 1, cores = 1) {
+                   data_var = NULL, packages = NULL, model_var = NULL,
+                   inference_opts = NULL, chains = 1, cores = 1) {
 
   run_fun <- function(k) run_webppl(program_code = program_code,
                                     program_file = program_file,
@@ -374,8 +443,6 @@ webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
                                     packages = packages,
                                     model_var = model_var,
                                     inference_opts = inference_opts,
-                                    random_seed = random_seed,
-                                    sort_by = sort_by,
                                     chains = chains,
                                     chain = k)
   if (chains == 1) {
@@ -389,7 +456,7 @@ webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
 
 #' Kill rwebppl processes
 #'
-#' @param pids (optional) Vector of process IDs to kill (defaults to killing all
+#' @param pid (optional) Vector of process IDs to kill (defaults to killing all
 #'   rwebppl processes)
 #'
 #' @export
@@ -398,8 +465,14 @@ webppl <- function(program_code = NULL, program_file = NULL, data = NULL,
 #' \dontrun{kill_webppl()}
 #' \dontrun{kill_webppl(6939)}
 kill_webppl <- function(pids = NULL) {
-  if (is.null(pids)){
-    pids <- system2("pgrep", args = c("-f", "webppl_program"), stdout = T)
+  if (is.null(pids)) {
+    if (system_os() == "Windows")
+    {
+      pids <- system("powershell -ExecutionPolicy ByPass -Command Get-Process webppl_program | Select -Expand id")
+    }
+    else {
+      pids <- system2("pgrep", args = c("-f", "webppl_program"), stdout = T)
+    }
   }
   tools::pskill(pids)
 }

--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -121,7 +121,7 @@ check_webppl <- function() {
 get_webppl_version <- function() {
   if (file_exists(webppl_executable())) {
     if (system_os() == "Windows") {
-      version_str <- substr(system(paste("node", paste("\"", webppl_executable(), "\"", sep=""), "--version"), intern = T), 1, 6) 
+      version_str <- system(paste("node", paste("\"", webppl_executable(), "\"", sep=""), "--version"), intern = T) 
     }
     else {
       version_str <- system2(webppl_executable(), args = c("--version"), stdout = T)  

--- a/R/rwebppl.R
+++ b/R/rwebppl.R
@@ -89,9 +89,9 @@ install_webppl <- function(webppl_version) {
   } else {
     # This doesn't work for Windows yet
     if (system_os() == "Windows") {
-      # system(paste("powershell -ExecutionPolicy ByPass -File", 
-      #              paste("\"", file.path(rwebppl_path(), "powershell", "install-dev-webppl.ps1"), "\"", sep=""), 
-      #              paste("\"", rwebppl_path(), "\"", sep=""), webppl_version))
+      system(paste("powershell -ExecutionPolicy ByPass -File", 
+                   paste("\"", file.path(rwebppl_path(), "powershell", "install-dev-webppl.ps1"), "\"", sep=""), 
+                   paste("\"", rwebppl_path(), "\"", sep=""), webppl_version))
     }
     else {
       system2(file.path(rwebppl_path(), "bash", "install-dev-webppl.sh"),

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ RWebPPL is an R package providing an interface to [WebPPL](https://github.com/pr
 ## Installation
 
 #### System requirements
-+ Linux, Mac, or Windows 10
-+ [R v3.3](https://cran.cnr.berkeley.edu) (in RStudio, type `version`)
-+ [node](https://nodejs.org/en/) v4.4.5 or higher (in your command-line interface (CLI; e.g., Terminal/Windows PowerShell/Command Prompt), type `node --version`; close and re-open your CLI after install)
-+ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in your CLI, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen your CLI and check version)
++ Mac, Linux OS, or Windows 10/11
++ [R v3.3](https://cran.cnr.berkeley.edu) (or possible newer; in RStudio, type `version`)
++ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal, type `node --version`; close and re-open terminal after install)
++ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen terminal and check version)
++ (for Windows users) [git](https://gitforwindows.org/) v2.42.0 or higher (in Terminal or CLI, type `git --version`)
 + devtools R library: in R: `install.packages('devtools')`
 
 ```
@@ -19,34 +20,23 @@ devtools::install_github("mhtess/rwebppl")
 
 RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
 
-## Usage
+## Primary features
 
-### Current list of function arguments and supported functionality
+For a complete introduction to RWebPPL's functionality, see [this introduction](https://github.com/mhtess/rwebppl/wiki/Introduction). 
 
-+ `program_code`: A string of a webppl program
-+ `program_file`: A file containing a webppl program
-+ `data`: A data frame (or other serializable object) to be passed from R to the webppl program
-+ `data_var`: A name by which the data can be referenced in the webppl program
-+ `packages`: A character vector of names of external webppl package to use
-+ `model_var`: When using inference opts, the name by which the model be referenced in the program.
-+ `inference_opts`: A list with options for inference of a particular model in the program. (see http://webppl.readthedocs.io/en/master/inference.html) [N.B.: requires using `model_var`]
-+ `chains`: Number of times to run program (defaults to 1).
-+ `cores`: Number of cores to use when running multiple chains (defaults to 1).
-
-
-### Examples
+### Running models from R
 
 Write a model as a string in R:
 
 ```
-my_model <- "
-var model = function () {
- var a = flip(0.3)
- var b = flip(0.6)
- return a + b
-}
-model()
-"
+my_model <- '
+   var model = function () {
+      var a = flip(0.3)
+      var b = flip(0.6)
+      return a + b
+   }
+   model()
+'
 webppl(my_model)
 ```
 
@@ -56,70 +46,34 @@ Or write a model in an external file:
 webppl(program_file = "path/to/model/model.wppl")
 ```
 
-[WebPPL packages](http://webppl.readthedocs.io/en/master/packages.html) can be used in more complex models:
-
-```
-webppl(program_file = "path/to/model/model.wppl",
-       packages = c("linked-list", "timeit"))
-```
-
-[List of useful packages.](https://github.com/probmods/webppl/wiki/Useful-packages)
-
-NPM packages that ares used inside of WebPPL packages can be installed directly from RWebPPL e.g. `install_webppl_package("babyparse")`. They can also be uninstalled in the same way: `uninstall_webppl_package("babyparse")`
-
-## Passing data from R to WebPPL
+### Passing data to WebPPL from R
 
 Data can be passed directly from R to WebPPL as in:
 
 ```
-my_model <- "
-var model = function () {
- var a = flip(0.3)
- var b = flip(0.6)
- var scores = map( function(d) {
- 	return a + b - d
- }, myDF)
- return scores
-}
-model()
-"
+my_model <- '
+    var model = function(){
+        var p = uniform(0, 1)
+        map(function(d){
+           observe(Binomial({n: d.n, p: p}), d.k)
+        }, myDF)
+  return p
+    }
+    Infer({model: model, method: "MCMC"})
+'
 
-webppl(my_model,
-	   data = df,
-	   data_var = "myDF")
+webppl(my_model, data = df, data_var = "myDF")
 ```
 
-In this example, `myDF` is not defined inside the WebPPL program, but is passed into it from R, using `data = df`. The argument `data_var` tells WebPPL what the data should be called.
+In this example, `myDF` is not defined inside the WebPPL program, but is passed into it from R, using `data = df`. The argument `data_var` tells WebPPL what the data should be called. If unspecified, `data_var` will default to `"data"`.
 
-### Structure of data when passing
-
-If `myDF` looks like this in R:
-
-| Participant | Condition | Response |
-|-------------|-----------|----------|
-| 1           | A         | 0.4      |
-| 1           | B         | 0.8      |
-| 2           | A         | 0.2      |
-
-It will exist in WebPPL as a list of js objects e.g.
+### Running multiple chains (in parallel)
 
 ```
-[
-  {
-    participant: 0,
-    condition: "A",
-    response: 0.4
-  },
-  {
-    participant: 0,
-    condition: "B",
-    response: 0.8
-  },
-  {
-    participant: 1,
-    condition: "A",
-    response: 0.2
-  },
-  ...
-]
+webppl(my_model, chains = 3, cores = 3)
 ```
+
+### Other options
+
+- specifying inference options in R
+- setting a random seed in R

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ RWebPPL is an R package providing an interface to [WebPPL](https://github.com/pr
 #### System requirements
 + Linux, Mac, or Windows 10
 + [R v3.3](https://cran.cnr.berkeley.edu) (in RStudio, type `version`)
-+ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal/Windows PowerShell/Command Prompt, type `node --version`; close and re-open CLI after install)
-+ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal/Windows PowerShell/Command Prompt, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen CLI and check version)
++ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal/Windows PowerShell/Command Prompt, type `node --version`; close and re-open your command-line interface after install)
++ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal/Windows PowerShell/Command Prompt, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen your command-line interface and check version)
 + devtools R library: in R: `install.packages('devtools')`
-
-RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
 
 #### For Linux/Mac users
 
@@ -24,7 +22,9 @@ devtools::install_github("mhtess/rwebppl")
 #### For Windows 10 users
 
 1. Clone/download this repository anywhere on your machine
-2. Open RStudio and enter `install.packages(path_to_repository, repos=NULL, type="source")` where path_to_repository is the location to where you cloned the repository
+2. Open RStudio and enter `install.packages(path_to_repository, repos=NULL, type="source")` where path_to_repository points to your download
+
+RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,24 @@ RWebPPL is an R package providing an interface to [WebPPL](https://github.com/pr
 ## Installation
 
 #### System requirements
-+ Mac or Linux OS [Windows currently not supported]
++ Linux, Mac, or Windows 10
 + [R v3.3](https://cran.cnr.berkeley.edu) (in RStudio, type `version`)
-+ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal, type `node --version`; close and re-open terminal after install)
-+ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen terminal and check version)
++ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal/Windows PowerShell/Command Prompt, type `node --version`; close and re-open CLI after install)
++ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal/Windows PowerShell/Command Prompt, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen CLI and check version)
 + devtools R library: in R: `install.packages('devtools')`
+
+RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
+
+#### For Linux/Mac users
 
 ```
 devtools::install_github("mhtess/rwebppl")
 ```
 
-RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
+#### For Windows 10 users
+
+1. Clone/download this repository anywhere on your machine
+2. Open RStudio and enter `install.packages(path_to_repository, repos=NULL, type="source")` where path_to_repository is the location to where you cloned the repository
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,13 @@ RWebPPL is an R package providing an interface to [WebPPL](https://github.com/pr
 #### System requirements
 + Linux, Mac, or Windows 10
 + [R v3.3](https://cran.cnr.berkeley.edu) (in RStudio, type `version`)
-+ [node](https://nodejs.org/en/) v4.4.5 or higher (in Terminal/Windows PowerShell/Command Prompt, type `node --version`; close and re-open your command-line interface after install)
-+ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in Terminal/Windows PowerShell/Command Prompt, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen your command-line interface and check version)
++ [node](https://nodejs.org/en/) v4.4.5 or higher (in your command-line interface (CLI; e.g., Terminal/Windows PowerShell/Command Prompt), type `node --version`; close and re-open your CLI after install)
++ [npm](https://docs.npmjs.com/getting-started/installing-node) v3.6 or higher (in your CLI, type `npm --version`; if it's not >= v3.6; try `sudo npm install npm -g`, close and reopen your CLI and check version)
 + devtools R library: in R: `install.packages('devtools')`
-
-#### For Linux/Mac users
 
 ```
 devtools::install_github("mhtess/rwebppl")
 ```
-
-#### For Windows 10 users
-
-1. Clone/download this repository anywhere on your machine
-2. Open RStudio and enter `install.packages(path_to_repository, repos=NULL, type="source")` where path_to_repository points to your download
 
 RWebPPL always installs its own local version of WebPPL for stability: by default, it will install the most recent, compatible release. Advanced users may use the `install_webppl()` function to override this default to install from any official NPM release tag (e.g. '0.9.7') or any commit hash from the WebPPL github repository.
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,7 @@ my_model <- '
         map(function(d){
            observe(Binomial({n: d.n, p: p}), d.k)
         }, myDF)
-<<<<<<< HEAD
-  return p
-=======
-	return p
->>>>>>> upstream/master
+        return p
     }
     Infer({model: model, method: "MCMC"})
 '

--- a/inst/powershell/install-dev-webppl.ps1
+++ b/inst/powershell/install-dev-webppl.ps1
@@ -1,0 +1,9 @@
+RWEBPPL=$args[0]
+VERSION=$args[1]
+
+cd $RWEBPPL/js
+npm install webppl@$VERSION
+mv node_modules/webppl webppl
+rm -r node_modules
+cd webppl
+npm install

--- a/inst/powershell/install-dev-webppl.ps1
+++ b/inst/powershell/install-dev-webppl.ps1
@@ -1,5 +1,0 @@
-$RWEBPPL=$args[0]
-$COMMIT=$args[1]
-
-cd 'C:/Users/Michael Lopez-Brau/Desktop/'
-git clone https://github.com/probmods/webppl.git

--- a/inst/powershell/install-dev-webppl.ps1
+++ b/inst/powershell/install-dev-webppl.ps1
@@ -1,0 +1,5 @@
+$RWEBPPL=$args[0]
+$COMMIT=$args[1]
+
+cd 'C:/Users/Michael Lopez-Brau/Desktop/'
+git clone https://github.com/probmods/webppl.git

--- a/inst/powershell/install-webppl.ps1
+++ b/inst/powershell/install-webppl.ps1
@@ -1,0 +1,4 @@
+$RWEBPPL=$args[0]
+
+cd $RWEBPPL/js
+npm install

--- a/inst/powershell/install_package.ps1
+++ b/inst/powershell/install_package.ps1
@@ -1,0 +1,11 @@
+$INST=$args[0]
+$PKG=$args[1]
+$RWEBPPL=$args[2]
+
+mkdir -p $INST
+cd $INST
+$CHKFILE=Test-Path ./package.json
+If ( -Not $CHKFILE ) {
+    cp $RWEBPPL/json/webppl-packages.json ./package.json
+}
+npm install $PKG

--- a/inst/powershell/rearrange-webppl.ps1
+++ b/inst/powershell/rearrange-webppl.ps1
@@ -1,0 +1,6 @@
+$RWEBPPL=$args[0]
+
+cd $RWEBPPL/js
+
+mv node_modules/webppl/ .
+mv node_modules webppl/node_modules

--- a/inst/powershell/uninstall_package.ps1
+++ b/inst/powershell/uninstall_package.ps1
@@ -1,0 +1,8 @@
+$INST=$args[0]
+$PKG=$args[1]
+
+$CHKDIR=Test-Path $INST
+If ( $CHKDIR ) {
+    cd $INST
+    npm uninstall $PKG
+}

--- a/man/kill_webppl.Rd
+++ b/man/kill_webppl.Rd
@@ -7,7 +7,7 @@
 kill_webppl(pids = NULL)
 }
 \arguments{
-\item{pids}{(optional) Vector of process IDs to kill (defaults to killing all
+\item{pid}{(optional) Vector of process IDs to kill (defaults to killing all
 rwebppl processes)}
 }
 \description{

--- a/man/run_webppl.Rd
+++ b/man/run_webppl.Rd
@@ -4,10 +4,17 @@
 \alias{run_webppl}
 \title{webppl}
 \usage{
-run_webppl(program_code = NULL, program_file = NULL, data = NULL,
-  data_var = "data", packages = NULL, model_var = "model",
-  inference_opts = NULL, chains = NULL, random_seed = NULL,
-  sort_by = "prob", chain = 1)
+run_webppl(
+  program_code = NULL,
+  program_file = NULL,
+  data = NULL,
+  data_var = NULL,
+  packages = NULL,
+  model_var = NULL,
+  inference_opts = NULL,
+  chains = NULL,
+  chain = 1
+)
 }
 \arguments{
 \item{program_code}{A string of a webppl program.}
@@ -27,10 +34,6 @@ referenced in the program.}
 (see http://webppl.readthedocs.io/en/master/inference.html)}
 
 \item{chains}{Number of chains (this run is one chain).}
-
-\item{random_seed}{Seed for random number generator}
-
-\item{sort_by}{Sort probability table by probability or support (enumeration only)}
 
 \item{chain}{Chain number of this run.}
 }

--- a/man/webppl.Rd
+++ b/man/webppl.Rd
@@ -4,10 +4,17 @@
 \alias{webppl}
 \title{webppl}
 \usage{
-webppl(program_code = NULL, program_file = NULL, data = NULL,
-  data_var = "data", packages = NULL, model_var = "model",
-  inference_opts = NULL, random_seed = NULL, sort_by = "prob",
-  chains = 1, cores = 1)
+webppl(
+  program_code = NULL,
+  program_file = NULL,
+  data = NULL,
+  data_var = NULL,
+  packages = NULL,
+  model_var = NULL,
+  inference_opts = NULL,
+  chains = 1,
+  cores = 1
+)
 }
 \arguments{
 \item{program_code}{A string of a webppl program.}
@@ -25,10 +32,6 @@ referenced in the program.}
 
 \item{inference_opts}{Options for inference
 (see http://webppl.readthedocs.io/en/master/inference.html)}
-
-\item{random_seed}{Seed for random number generator}
-
-\item{sort_by}{Sort probability table by probability or support (enumeration only)}
 
 \item{chains}{Number of times to run the program (defaults to 1).}
 


### PR DESCRIPTION
- Updated most of the functions in rwebppl.R to be Windows-compatible by including conditionals based on the user's OS.
- Added a new folder under `inst` named `powershell`. This folder contains installation scripts for Windows users that are the equivalent to those found in `inst/bash`. 

The only feature that is currently still *not* supported is installing via GitHub since Windows doesn't natively support git.
